### PR TITLE
Fix: Enhance active navigation link visibility

### DIFF
--- a/assets/css/_nav.css
+++ b/assets/css/_nav.css
@@ -26,11 +26,17 @@
   white-space: nowrap; /* Prevent wrapping */
 }
 
-.nav-button:hover,
-.nav-button.active {
+.nav-button:hover {
   color: var(--accent);
-  border-bottom-color: var(--accent);
-  font-weight: 400; /* Slightly bolder when active/hover */
+  border-bottom-color: var(--accent); /* Keep existing hover border */
+  font-weight: 400; /* Keep existing font weight for hover */
+}
+
+.nav-button.active {
+  color: var(--accent); /* Keep accent text color */
+  background-color: var(--highlight); /* Add background color */
+  border-bottom: 3px solid var(--accent); /* Thicker, solid border */
+  font-weight: 500; /* Bolder than default and hover */
 }
 
 @media (max-width: 600px) {

--- a/hugo.toml
+++ b/hugo.toml
@@ -9,9 +9,25 @@ title = 'laundromatzat.com'
 
 [menu]
   [[menu.main]]
+    name = "home"
+    pageRef = "/"
+    weight = 0
+  [[menu.main]]
     name = "videos"
-    url = "/videos/"
+    pageRef = "/videos"
     weight = 1
+  [[menu.main]]
+    name = "cinemagraphs"
+    pageRef = "/cinemagraphs"
+    weight = 2
+  [[menu.main]]
+    name = "images"
+    pageRef = "/images"
+    weight = 3
+  [[menu.main]]
+    name = "about"
+    pageRef = "/about.md"
+    weight = 4
 
 [outputs]
   home = ["HTML", "RSS"]

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -40,12 +40,18 @@
              laundromatzat.com
            </a>
           <div class="main-nav-container">
-            {{/* Using data attributes to help JS identify sections easily */}}
-            <a data-nav-section="/" hx-get="/" hx-select="#content-container" hx-target="#content-container" hx-push-url="true" hx-trigger="click" hx-indicator="#indicator" class="nav-button {{ if .IsHome }}active{{ end }}">home</a>
-            <a data-nav-section="/videos" hx-get="/videos" hx-select="#content-container" hx-target="#content-container" hx-push-url="true" hx-trigger="click" hx-indicator="#indicator" class="nav-button {{ if eq .Section "videos" }}active{{ end }}">videos</a>
-            <a data-nav-section="/cinemagraphs" hx-get="/cinemagraphs" hx-select="#content-container" hx-target="#content-container" hx-push-url="true" hx-trigger="click" hx-indicator="#indicator" class="nav-button {{ if eq .Section "cinemagraphs" }}active{{ end }}">cinemagraphs</a>
-            <a data-nav-section="/images" hx-get="/images" hx-select="#content-container" hx-target="#content-container" hx-push-url="true" hx-trigger="click" hx-indicator="#indicator" class="nav-button {{ if eq .Section "images" }}active{{ end }}">images</a>
-            <a data-nav-section="/about" hx-get="/about" hx-select="#content-container" hx-target="#content-container" hx-push-url="true" hx-trigger="click" hx-indicator="#indicator" class="nav-button {{ if eq .RelPermalink "/about/" }}active{{ end }}">about</a>
+            {{ $currentPage := . }}
+            {{ range .Site.Menus.main.ByWeight }}
+              <a data-nav-section="{{ .URL }}"
+                 hx-get="{{ .URL }}"
+                 hx-select="#content-container"
+                 hx-target="#content-container"
+                 hx-push-url="true"
+                 hx-trigger="click"
+                 hx-indicator="#indicator"
+                 class="nav-button {{ if $currentPage.IsMenuCurrent "main" . }}active{{ else if (and (eq .Name "home") ($currentPage.IsHome)) }}active{{ end }}"
+                 href="{{ .URL }}">{{ .Name }}</a>
+            {{ end }}
             <span class="htmx-indicator" id="indicator">Loading...</span>
           </div>
         </div>


### PR DESCRIPTION
This commit improves the visual distinction of the active page link in the main navigation header.

Key changes:
- Modified `assets/css/_nav.css`:
    - Separated the CSS rules for `.nav-button:hover` and `.nav-button.active`.
    - Enhanced the `.nav-button.active` style with:
        - A subtle background color (`var(--highlight)`).
        - A thicker bottom border (3px, `var(--accent)`). - Increased font weight (500).
- Updated `hugo.toml`:
    - Defined all main navigation links (Home, Videos, Cinemagraphs, Images, About) within the `[menu.main]` configuration using `pageRef` for robustness.
- Updated `layouts/_default/baseof.html`:
    - Replaced hardcoded navigation links with a Hugo template loop that iterates over `site.Menus.main.ByWeight`.
    - Applied the `active` class using Hugo's `IsMenuCurrent` logic, ensuring accurate highlighting based on the menu configuration.

These changes make it clearer to you which page you are currently on, improving the overall navigation experience. The use of Hugo's menu system also centralizes navigation logic and follows best practices.