### PR TITLE
feat: Implement "Behind the Lens" insights feature

### DIFF
--- a/assets/css/_behind-the-lens.css
+++ b/assets/css/_behind-the-lens.css
@@ -1,0 +1,41 @@
+/* _behind-the-lens.css */
+
+.behind-the-lens__icon {
+    font-size: 1.2em; /* Adjust as needed */
+    color: #fff; /* Or a color that fits the theme */
+    cursor: pointer;
+    margin-left: 10px; /* Adjust as needed */
+    transition: color 0.3s ease;
+    /* Potential positioning - might need to be adjusted based on parent */
+    /* position: absolute; */
+    /* bottom: 10px; */
+    /* right: 10px; */
+}
+
+.behind-the-lens__icon:hover {
+    color: #ccc; /* Lighter color on hover */
+}
+
+.behind-the-lens__content {
+    background-color: #f9f9f9; /* Light background */
+    color: #333; /* Darker text for readability */
+    padding: 15px;
+    margin-top: 10px; /* Space above the content box */
+    border-radius: 5px;
+    box-shadow: 0 2px 5px rgba(0,0,0,0.1);
+    /* Ensure it's hidden by default if JS fails, though JS handles display */
+    /* display: none; */
+}
+
+.behind-the-lens__content h3 {
+    margin-top: 0;
+    margin-bottom: 10px;
+    font-size: 1.1em;
+    color: #111;
+}
+
+.behind-the-lens__content p {
+    font-size: 0.9em;
+    line-height: 1.6;
+    margin-bottom: 0;
+}

--- a/assets/js/behind-the-lens.js
+++ b/assets/js/behind-the-lens.js
@@ -1,0 +1,21 @@
+document.addEventListener('DOMContentLoaded', function () {
+    const icons = document.querySelectorAll('.behind-the-lens__icon');
+
+    icons.forEach(icon => {
+        icon.addEventListener('click', function () {
+            // Adjust the parent selector based on the actual HTML structure
+            // This assumes the icon and content are siblings or the content is a sibling of the icon's parent
+            const contentWrapper = icon.closest('.video-grid__thumbnail-wrapper, .image-item, .cinemagraph-item');
+            if (contentWrapper) {
+                const content = contentWrapper.querySelector('.behind-the-lens__content');
+                if (content) {
+                    if (content.style.display === 'none' || content.style.display === '') {
+                        content.style.display = 'block';
+                    } else {
+                        content.style.display = 'none';
+                    }
+                }
+            }
+        });
+    });
+});

--- a/content/cinemagraphs/sample-cinemagraph.md
+++ b/content/cinemagraphs/sample-cinemagraph.md
@@ -3,5 +3,6 @@ title: "Sample Cinemagraph"
 firebase_url: "https://example.com/sample-cinemagraph.mp4"
 original_filename: "sample-cinemagraph.mp4"
 type: "cinemagraph"
+behind_the_lens: "Creating this cinemagraph required meticulous attention to detail in post-production to ensure a seamless loop."
 feat: true
 ---

--- a/content/images/sample-image.md
+++ b/content/images/sample-image.md
@@ -3,6 +3,7 @@ title: "Sample Image"
 firebase_url: "https://example.com/sample-image.jpg"
 original_filename: "sample-image.jpg"
 type: "image"
+behind_the_lens: "This image involved a long hike to a remote location. I used a long exposure to capture the movement of the clouds."
 alt_text: "A sample image"
 width: 1920
 height: 1080

--- a/content/videos/sample-video.md
+++ b/content/videos/sample-video.md
@@ -5,5 +5,6 @@ original_filename: "sample-video.m4v"
 type: "video"
 location: "Sample Location"
 thumbnail: "https://example.com/sample-video-thumb.jpg"
+behind_the_lens: "This video was shot during a spontaneous road trip. The biggest challenge was capturing the perfect light during the golden hour."
 description: "This is a sample video."
 ---

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -13,6 +13,9 @@
 
     <link rel="shortcut icon" href="/favicon.ico" type="image/x-icon">
 
+    {{/* Font Awesome CDN Link */}}
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.4/css/all.min.css" integrity="sha512-1ycn6IcaQQ40/MKBW2W4Rhis/DbILU74C1vSrLJxCq57o941Ym01SwNsOMqvEBFlcgUa6xLiPY/NS5R+E6ztJQ==" crossorigin="anonymous" referrerpolicy="no-referrer" />
+
     {{ $needsMasonry := false }}
     {{ if eq .RelPermalink "/images/" }} {{/* Condition to load Masonry only on images page */}}
       {{ $needsMasonry = true }}
@@ -75,6 +78,15 @@
     {{/* ... (footer tag above this) ... */}}
 
     {{/* --- Load External Javascript --- */}}
+    {{/* Process behind-the-lens.js with Hugo Pipes for fingerprinting/minification */}}
+    {{ $behindTheLensJS := resources.Get "js/behind-the-lens.js" | js.Build (dict "minify" true) | fingerprint }}
+    {{ if $behindTheLensJS }}
+      <script src="{{ $behindTheLensJS.RelPermalink }}" integrity="{{ $behindTheLensJS.Data.Integrity }}" defer></script>
+    {{ else }}
+      {{/* Fallback or warning if js/behind-the-lens.js is not found */}}
+      <script>console.error("behind-the-lens.js not found in assets/js/");</script>
+    {{ end }}
+
     {{/* Process main.js with Hugo Pipes for fingerprinting/minification */}}
     {{ $mainJS := resources.Get "js/main.js" | js.Build (dict "minify" true) | fingerprint }}
     {{ if $mainJS }}

--- a/layouts/cinemagraphs/list.html
+++ b/layouts/cinemagraphs/list.html
@@ -27,7 +27,14 @@
            {{ with .location }}<p class="location">{{ . }}</p>{{ end }}
            {{ with .date }}<p class="date">{{ . }}</p>{{ end }}
          </div>
+         <i class="fas fa-camera behind-the-lens__icon"></i>
       </div>
+      {{ with $item.behind_the_lens }}
+      <div class="behind-the-lens__content" style="display: none;">
+        <h3>Behind the Lens</h3>
+        <p>{{ . }}</p>
+      </div>
+      {{ end }}
     </div>
   {{ end }}
 </div>

--- a/layouts/images/list.html
+++ b/layouts/images/list.html
@@ -19,7 +19,14 @@
           {{ with .location }}<p class="location">{{ . }}</p>{{ end }}
           {{ with .date }}<p class="date">{{ . }}</p>{{ end }}
         </div>
+        <i class="fas fa-camera behind-the-lens__icon"></i>
       </div>
+      {{ with $item.behind_the_lens }}
+      <div class="behind-the-lens__content" style="display: none;">
+        <h3>Behind the Lens</h3>
+        <p>{{ . }}</p>
+      </div>
+      {{ end }}
     </div>
   {{ end }}
 </div>

--- a/layouts/videos/list.html
+++ b/layouts/videos/list.html
@@ -29,7 +29,14 @@
               {{ with .location }}<p class="location">{{ . }}</p>{{ end }}
               {{ with .date }}<p class="date">{{ . }}</p>{{ end }}
             </div>
+            <i class="fas fa-camera behind-the-lens__icon"></i>
           </div>
+          {{ with .behind_the_lens }}
+          <div class="behind-the-lens__content" style="display: none;">
+            <h3>Behind the Lens</h3>
+            <p>{{ . }}</p>
+          </div>
+          {{ end }}
         </div>
       </div>
     {{ end }}


### PR DESCRIPTION
This commit introduces the "Behind the Lens" feature, allowing you to add "making-of" notes to your portfolio items.

Key changes:

- Added a `behind_the_lens` field to the front matter of portfolio Markdown files.
- Updated HTML layouts (`videos/list.html`, `images/list.html`, `cinemagraphs/list.html`) to:
    - Display a camera icon for each portfolio item.
    - Include a hidden div to store the "Behind the Lens" content.
- Added JavaScript (`assets/js/behind-the-lens.js`) to toggle the visibility of the content when the icon is clicked.
- Added CSS (`assets/css/_behind-the-lens.css`) to style the icon and the content section.
- Included Font Awesome via CDN in `layouts/_default/baseof.html` to ensure proper icon rendering.

The feature allows you to click an icon to view additional details and anecdotes about each piece, enhancing engagement and providing deeper insight into the creative process.