### PR TITLE
git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,3 +73,13 @@ functions/serviceAccountKey.json
 
 #example files
 /examples
+
+# Hugo specific
+public/
+resources/
+hugo_stats.json
+.hugo_build.lock
+hugo
+
+# OS specific
+**/.DS_Store


### PR DESCRIPTION
Here's an update to your `.gitignore` and how I've untracked some build artifacts:

This commit introduces the following changes:

1. Updates `.gitignore` to exclude common Hugo build outputs,
   OS-specific files, and temporary files. Specifically, I've added:
   - `public/`
   - `resources/`
   - `hugo_stats.json`
   - `.hugo_build.lock`
   - `hugo` (binary)
   - `**/.DS_Store`

2. I've untracked the following files and patterns from the repository:
   - `hugo_stats.json`
   - `.hugo_build.lock`
   - `hugo` (binary at root)
   - Various `.DS_Store` files

IMPORTANT:
Due to some limitations, I couldn't automatically untrack the `public/` and `resources/` directories.
You'll need to manually untrack these by running the following commands in your local repository:

```
git rm -r --cached public
git rm -r --cached resources
```

After running these commands, please commit the changes.