### PR TITLE
Fix: Replace deprecated "warn" function with "warnf"

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -36,7 +36,7 @@
     <link rel="stylesheet" href="{{ $styles.RelPermalink }}" integrity="{{ $styles.Data.Integrity }}">
     {{ else }}
     <link rel="stylesheet" href="/css/fallback.css">
-    {{ warn "CSS pipeline failed, loading fallback styles." }}
+    {{ warnf "CSS pipeline failed, loading fallback styles." }}
     {{ end }}
 
     {{ template "_internal/opengraph.html" . }}


### PR DESCRIPTION
The "warn" function was deprecated and removed in recent Hugo versions, causing the GitHub Pages build to fail. This commit replaces "warn" with "warnf" in the `baseof.html` template to resolve the build error.