### PR TITLE
Fix: Correct Node.js dependency installation in GitHub Actions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -39,8 +39,8 @@ jobs:
       - name: Check Hugo version
         run: hugo version
 
-      - name: Install PostCSS and autoprefixer
-        run: npm install -g postcss-cli autoprefixer postcss-preset-env
+      - name: Install Node.js dependencies
+        run: npm install
       
       - name: Build Hugo site
         run: hugo --minify  # Removed the --verbose flag


### PR DESCRIPTION
The Hugo build process was failing on GitHub Pages because PostCSS plugins, specifically 'postcss-preset-env', could not be found. This was due to the workflow installing these dependencies globally instead of locally within the project.

This commit modifies the `.github/workflows/deploy.yml` file to:
- Remove the global installation of PostCSS packages.
- Add a new step to run `npm install`, which installs all dependencies listed in `package.json` locally into the `node_modules` directory.

This ensures that Hugo's PostCSS processor can find the required plugins, allowing the build to complete successfully.