### PR TITLE
Fix nav icon path

### DIFF
--- a/index.tsx
+++ b/index.tsx
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
 */
 import React, { useState, useEffect, useRef, useMemo } from 'react';
+import siteIcon from './images/laundromatzat-icon.png';
 import ReactDOM from 'react-dom/client';
 
 // !!! IMPORTANT: REPLACE WITH YOUR ACTUAL PUBLISHED GOOGLE SHEET CSV URL !!!
@@ -238,7 +239,7 @@ function NavigationBar({
         <a href="/" className="site-title" aria-label="Homepage">
           {/* 1️⃣ Add your icon here */}
           <img
-            src="/images/laundromatzat-icon.png"
+            src={siteIcon}
             alt="laundromatzat.com logo"
             className="site-icon"
           />

--- a/vite-env.d.ts
+++ b/vite-env.d.ts
@@ -1,0 +1,4 @@
+declare module '*.png' {
+  const src: string;
+  export default src;
+}


### PR DESCRIPTION
## Summary
- import the nav icon so Vite includes it in the build
- declare `*.png` module types for TypeScript

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_685f3131849483218e942efcd8ccd44d