### PR TITLE
Add animated dark modal overlay with navigation

### DIFF
--- a/index.css
+++ b/index.css
@@ -475,43 +475,50 @@ a {
   left: 0;
   width: 100%;
   height: 100%;
-  background-color: rgba(0, 0, 0, 0.75); 
+  background-color: rgba(0, 0, 0, 0);
+  animation: fadeInBackdrop 2s forwards;
   display: flex;
   justify-content: center;
   align-items: center;
-  z-index: 2000; 
-  padding: 20px; 
+  z-index: 2000;
+  padding: 20px;
+  backdrop-filter: blur(5px);
+}
+
+@keyframes fadeInBackdrop {
+  from { background-color: rgba(0, 0, 0, 0); }
+  to { background-color: rgba(0, 0, 0, 0.7); }
 }
 
 .modal-dialog {
-  background-color: var(--color-bg); 
+  background-color: transparent;
   border-radius: 8px;
-  box-shadow: 0 5px 20px var(--color-shadow-base); 
-  padding: 25px; 
+  box-shadow: none;
+  padding: 25px;
   position: relative;
-  max-width: 90vw; 
-  max-height: 90vh; 
+  max-width: 90vw;
+  max-height: 90vh;
   display: flex;
   flex-direction: column;
-  overflow: hidden; 
+  overflow: hidden;
 }
 
 .modal-close-button {
   position: absolute;
-  top: 15px; 
-  right: 15px; 
+  top: 15px;
+  right: 15px;
   background: none;
   border: none;
-  font-size: 2.2rem; 
+  font-size: 2.2rem;
   line-height: 1;
-  color: var(--color-text); 
+  color: var(--color-light-text-on-dark);
   cursor: pointer;
   padding: 0.25rem 0.5rem;
 }
 
 .modal-close-button:hover,
 .modal-close-button:focus {
-  color: var(--color-dark-accent); 
+  color: var(--color-accent);
 }
 
 .modal-content {
@@ -523,12 +530,12 @@ a {
 }
 
 .modal-title {
-  font-size: 1.6rem; 
+  font-size: 1.6rem;
   font-weight: 600;
   margin-top: 0;
   margin-bottom: 15px; /* Reduced from 20px */
-  color: var(--color-dark-text); 
-  padding-right: 40px; 
+  color: var(--color-light-text-on-dark);
+  padding-right: 40px;
   flex-shrink: 0; /* Prevent title from shrinking */
 }
 
@@ -551,8 +558,8 @@ a {
 }
 
 .modal-details {
-  font-size: 0.95rem; 
-  color: var(--color-text); 
+  font-size: 0.95rem;
+  color: var(--color-light-text-on-dark);
   overflow-y: hidden; /* Clip text if too long */
   flex-shrink: 0; /* Prevent details block from shrinking vertically */
 }
@@ -569,7 +576,7 @@ a {
 }
 
 .modal-details strong { /* No longer used in reformatted text, but kept for GPS/EasterEgg */
-  color: var(--color-dark-text); 
+  color: var(--color-light-text-on-dark);
 }
 
 .modal-description-reformatted {
@@ -581,8 +588,27 @@ a {
 
 
 .modal-easter-egg {
-  opacity: 0.7; 
+  opacity: 0.7;
   font-size: 0.8rem;
+  color: var(--color-light-text-on-dark);
 }
+
+.modal-nav {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  width: 50%;
+  background: none;
+  border: none;
+  color: var(--color-light-text-on-dark);
+  cursor: pointer;
+  font-size: 2rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.modal-nav.prev { left: 0; }
+.modal-nav.next { right: 0; }
 
 /* Leaflet Popup Customizations Removed */

--- a/index.tsx
+++ b/index.tsx
@@ -356,9 +356,11 @@ interface ModalProps {
   isOpen: boolean;
   onClose: () => void;
   item: PortfolioItemData | null;
+  onPrev: () => void;
+  onNext: () => void;
 }
 
-function Modal({ isOpen, onClose, item }: ModalProps) {
+function Modal({ isOpen, onClose, item, onPrev, onNext }: ModalProps) {
   const modalRef = useRef<HTMLDivElement>(null);
   const closeButtonRef = useRef<HTMLButtonElement>(null);
 
@@ -455,16 +457,23 @@ function Modal({ isOpen, onClose, item }: ModalProps) {
     <div
       className="modal-backdrop"
       onClick={onClose}
-      role="presentation" 
+      role="presentation"
     >
+      <button
+        className="modal-nav prev"
+        onClick={e => { e.stopPropagation(); onPrev(); }}
+        aria-label="Previous item"
+      >
+        ‹
+      </button>
       <div
         ref={modalRef}
         className="modal-dialog"
-        onClick={e => e.stopPropagation()} 
+        onClick={e => e.stopPropagation()}
         role="dialog"
         aria-modal="true"
         aria-labelledby={titleId}
-        aria-describedby={contentId} 
+        aria-describedby={contentId}
       >
         <button
           id={`modal-close-button-${item.id}`}
@@ -488,6 +497,13 @@ function Modal({ isOpen, onClose, item }: ModalProps) {
           </div>
         </div>
       </div>
+      <button
+        className="modal-nav next"
+        onClick={e => { e.stopPropagation(); onNext(); }}
+        aria-label="Next item"
+      >
+        ›
+      </button>
     </div>
   );
 }
@@ -508,6 +524,7 @@ function App() {
   const [error, setError] = useState<string | null>(null);
   const [isModalOpen, setIsModalOpen] = useState<boolean>(false);
   const [selectedModalItem, setSelectedModalItem] = useState<PortfolioItemData | null>(null);
+  const [currentIndex, setCurrentIndex] = useState<number>(-1);
   const [lastFocusedElement, setLastFocusedElement] = useState<HTMLElement | null>(null);
 
   const [availableTypesInSheet, setAvailableTypesInSheet] = useState<string[]>([]);
@@ -608,14 +625,31 @@ function App() {
 
   const handleOpenModal = (item: PortfolioItemData, targetElement: HTMLElement) => {
     setLastFocusedElement(targetElement || document.activeElement as HTMLElement);
+    const index = displayedItems.findIndex(i => i.id === item.id);
+    setCurrentIndex(index);
     setSelectedModalItem(item);
     setIsModalOpen(true);
   };
 
   const handleCloseModal = () => {
     setIsModalOpen(false);
-    setSelectedModalItem(null); 
+    setSelectedModalItem(null);
+    setCurrentIndex(-1);
     lastFocusedElement?.focus();
+  };
+
+  const handleNextModalItem = () => {
+    if (displayedItems.length === 0) return;
+    const nextIndex = (currentIndex + 1) % displayedItems.length;
+    setCurrentIndex(nextIndex);
+    setSelectedModalItem(displayedItems[nextIndex]);
+  };
+
+  const handlePrevModalItem = () => {
+    if (displayedItems.length === 0) return;
+    const prevIndex = (currentIndex - 1 + displayedItems.length) % displayedItems.length;
+    setCurrentIndex(prevIndex);
+    setSelectedModalItem(displayedItems[prevIndex]);
   };
 
   const handleSetActiveType = (typeToSet: string) => {
@@ -648,10 +682,12 @@ function App() {
         {/* PortfolioMap and related conditional rendering removed */}
 
       </main>
-      <Modal 
-        isOpen={isModalOpen} 
-        onClose={handleCloseModal} 
-        item={selectedModalItem} 
+      <Modal
+        isOpen={isModalOpen}
+        onClose={handleCloseModal}
+        item={selectedModalItem}
+        onPrev={handlePrevModalItem}
+        onNext={handleNextModalItem}
       />
       <Footer />
     </div>


### PR DESCRIPTION
## Summary
- fade modal backdrop to 70% black with blur
- remove white dialog background and use light text
- add previous/next navigation for portfolio items

## Testing
- `npm run build`
- `npx tsc --noEmit` *(fails: Could not find a declaration file for module 'react')*

------
https://chatgpt.com/codex/tasks/task_e_68616c5928948321b83d40960f2919a6