### PR TITLE
Add modal media viewer for portfolio projects

### DIFF
--- a/components/PortfolioModal.tsx
+++ b/components/PortfolioModal.tsx
@@ -1,0 +1,165 @@
+import React, { useEffect, useMemo, useRef } from 'react';
+import { Project, ProjectType } from '../types';
+import { CloseIcon } from './icons/CloseIcon';
+
+interface PortfolioModalProps {
+  projects: Project[];
+  currentIndex: number;
+  onClose: () => void;
+  onPrev: () => void;
+  onNext: () => void;
+}
+
+function PortfolioModal({ projects, currentIndex, onClose, onPrev, onNext }: PortfolioModalProps): React.ReactNode {
+  const project = projects[currentIndex];
+  const mediaContainerRef = useRef<HTMLDivElement | null>(null);
+  const videoRef = useRef<HTMLVideoElement | null>(null);
+
+  const mediaSrc = useMemo(() => project?.projectUrl || project?.imageUrl, [project]);
+  const isVideo = project?.type === ProjectType.Video || project?.type === ProjectType.Cinemagraph;
+
+  useEffect(() => {
+    document.body.style.overflow = 'hidden';
+    return () => {
+      document.body.style.overflow = '';
+    };
+  }, []);
+
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        onClose();
+      }
+
+      if (event.key === 'ArrowLeft') {
+        onPrev();
+      }
+
+      if (event.key === 'ArrowRight') {
+        onNext();
+      }
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [onClose, onPrev, onNext]);
+
+  useEffect(() => {
+    videoRef.current?.load();
+  }, [project]);
+
+  if (!project) {
+    return null;
+  }
+
+  const handleFullscreen = () => {
+    const container = mediaContainerRef.current as (HTMLDivElement & {
+      webkitRequestFullscreen?: () => Promise<void>;
+      mozRequestFullScreen?: () => Promise<void>;
+      msRequestFullscreen?: () => Promise<void>;
+    }) | null;
+
+    const requestFullscreen = container?.requestFullscreen
+      || container?.webkitRequestFullscreen
+      || container?.mozRequestFullScreen
+      || container?.msRequestFullscreen;
+
+    if (requestFullscreen) {
+      requestFullscreen.call(container);
+      return;
+    }
+
+    if (mediaSrc) {
+      window.open(mediaSrc, '_blank', 'noopener,noreferrer');
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center">
+      <div className="absolute inset-0 bg-black/70" onClick={onClose} aria-hidden="true" />
+      <div className="relative z-10 w-full max-w-5xl px-4">
+        <div className="bg-brand-secondary rounded-xl shadow-2xl overflow-hidden">
+          <div className="flex items-start justify-between px-6 py-4 border-b border-brand-accent/20">
+            <div>
+              <h2 className="text-xl sm:text-2xl font-semibold text-brand-text">{project.title}</h2>
+              <p className="text-sm text-brand-text-secondary mt-1">
+                {[project.date, project.location].filter(Boolean).join(' · ')}
+              </p>
+            </div>
+            <button
+              type="button"
+              onClick={onClose}
+              className="text-brand-text-secondary hover:text-brand-text focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-accent/60 rounded-full p-1"
+              aria-label="Close"
+            >
+              <CloseIcon className="h-6 w-6" />
+            </button>
+          </div>
+
+          <div ref={mediaContainerRef} className="relative bg-black">
+            {isVideo ? (
+              <video
+                key={project.id}
+                ref={videoRef}
+                className="w-full max-h-[70vh] object-contain bg-black"
+                controls
+                autoPlay
+                poster={project.imageUrl}
+              >
+                {mediaSrc && <source src={mediaSrc} />}
+                Your browser does not support the video tag.
+              </video>
+            ) : (
+              <img
+                key={project.id}
+                src={mediaSrc}
+                alt={project.title}
+                className="w-full max-h-[70vh] object-contain bg-black"
+              />
+            )}
+
+            <button
+              type="button"
+              onClick={onPrev}
+              className="absolute left-2 top-1/2 -translate-y-1/2 bg-black/60 hover:bg-black/80 text-white rounded-full p-3 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-accent/60"
+              aria-label="Previous project"
+            >
+              <span className="text-2xl leading-none">&#8249;</span>
+            </button>
+            <button
+              type="button"
+              onClick={onNext}
+              className="absolute right-2 top-1/2 -translate-y-1/2 bg-black/60 hover:bg-black/80 text-white rounded-full p-3 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-accent/60"
+              aria-label="Next project"
+            >
+              <span className="text-2xl leading-none">&#8250;</span>
+            </button>
+
+            <button
+              type="button"
+              onClick={handleFullscreen}
+              className="absolute bottom-4 right-4 bg-brand-accent text-white px-4 py-2 rounded-full shadow hover:bg-brand-accent/90 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-accent/60"
+            >
+              view fullscreen
+            </button>
+          </div>
+
+          <div className="px-6 py-4 text-brand-text-secondary text-sm sm:text-base">
+            <p>{project.description}</p>
+            {project.tags?.length ? (
+              <div className="mt-3 flex flex-wrap gap-2 text-xs uppercase tracking-wide text-brand-text-secondary/80">
+                {project.tags.map(tag => (
+                  <span key={tag} className="bg-brand-primary/20 px-3 py-1 rounded-full">
+                    {tag}
+                  </span>
+                ))}
+              </div>
+            ) : null}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default PortfolioModal;

--- a/components/ProjectCard.tsx
+++ b/components/ProjectCard.tsx
@@ -4,20 +4,34 @@ import { Project } from '../types';
 
 interface ProjectCardProps {
   project: Project;
+  onSelect?: () => void;
 }
 
-function ProjectCard({ project }: ProjectCardProps): React.ReactNode {
+function ProjectCard({ project, onSelect }: ProjectCardProps): React.ReactNode {
+  const handleClick = () => {
+    if (onSelect) {
+      onSelect();
+      return;
+    }
+
+    const targetUrl = project.projectUrl || project.imageUrl;
+    if (targetUrl) {
+      window.open(targetUrl, '_blank', 'noopener,noreferrer');
+    }
+  };
+
   return (
-    <div className="bg-brand-secondary rounded-lg overflow-hidden transform hover:-translate-y-1 transition-transform duration-300 ease-in-out shadow-lg hover:shadow-2xl hover:shadow-brand-accent/20 animate-slide-in-up">
-      <a href={project.projectUrl || project.imageUrl} target="_blank" rel="noopener noreferrer">
-        <img className="w-full h-56 object-cover" src={project.imageUrl} alt={project.title} />
-      </a>
+    <button
+      type="button"
+      onClick={handleClick}
+      className="bg-brand-secondary rounded-lg overflow-hidden transform hover:-translate-y-1 transition-transform duration-300 ease-in-out shadow-lg hover:shadow-2xl hover:shadow-brand-accent/20 animate-slide-in-up focus:outline-none focus-visible:ring-4 focus-visible:ring-brand-accent/60 w-full text-left"
+    >
+      <img className="w-full h-56 object-cover" src={project.imageUrl} alt={project.title} />
       <div className="p-6">
         <h3 className="text-lg sm:text-xl font-bold text-brand-text mb-2">{project.title}</h3>
         <p className="text-brand-text-secondary text-sm sm:text-base mb-4">{project.description}</p>
-        
       </div>
-    </div>
+    </button>
   );
 }
 

--- a/components/ProjectGrid.tsx
+++ b/components/ProjectGrid.tsx
@@ -1,0 +1,76 @@
+import React, { useCallback, useEffect, useState } from 'react';
+import { Project } from '../types';
+import ProjectCard from './ProjectCard';
+import PortfolioModal from './PortfolioModal';
+
+interface ProjectGridProps {
+  projects: Project[];
+  gridClassName?: string;
+}
+
+function ProjectGrid({ projects, gridClassName = 'grid grid-cols-2 md:grid-cols-2 lg:grid-cols-3 gap-8' }: ProjectGridProps): React.ReactNode {
+  const [activeIndex, setActiveIndex] = useState<number | null>(null);
+
+  useEffect(() => {
+    setActiveIndex(null);
+  }, [projects]);
+
+  const handleOpen = useCallback((index: number) => {
+    setActiveIndex(index);
+  }, []);
+
+  const handleClose = useCallback(() => {
+    setActiveIndex(null);
+  }, []);
+
+  const handlePrev = useCallback(() => {
+    setActiveIndex(prev => {
+      if (prev === null) {
+        return prev;
+      }
+
+      if (projects.length === 0) {
+        return null;
+      }
+
+      const previousIndex = (prev - 1 + projects.length) % projects.length;
+      return previousIndex;
+    });
+  }, [projects.length]);
+
+  const handleNext = useCallback(() => {
+    setActiveIndex(prev => {
+      if (prev === null) {
+        return prev;
+      }
+
+      if (projects.length === 0) {
+        return null;
+      }
+
+      const nextIndex = (prev + 1) % projects.length;
+      return nextIndex;
+    });
+  }, [projects.length]);
+
+  return (
+    <>
+      <div className={gridClassName}>
+        {projects.map((project, index) => (
+          <ProjectCard key={project.id} project={project} onSelect={() => handleOpen(index)} />
+        ))}
+      </div>
+      {activeIndex !== null && projects.length > 0 ? (
+        <PortfolioModal
+          projects={projects}
+          currentIndex={activeIndex}
+          onClose={handleClose}
+          onPrev={handlePrev}
+          onNext={handleNext}
+        />
+      ) : null}
+    </>
+  );
+}
+
+export default ProjectGrid;

--- a/pages/CinemagraphsPage.tsx
+++ b/pages/CinemagraphsPage.tsx
@@ -2,7 +2,7 @@
 import React from 'react';
 import { PROJECTS } from '../constants';
 import { ProjectType } from '../types';
-import ProjectCard from '../components/ProjectCard';
+import ProjectGrid from '../components/ProjectGrid';
 
 function CinemagraphsPage(): React.ReactNode {
   const cinemagraphProjects = PROJECTS.filter(p => p.type === ProjectType.Cinemagraph).sort((a, b) => {
@@ -19,11 +19,7 @@ function CinemagraphsPage(): React.ReactNode {
         <h1 className="text-3xl sm:text-4xl font-bold text-brand-text mb-2">cinemagraphs</h1>
         <p className="text-lg text-brand-text-secondary">picture that breathe.</p>
       </section>
-      <div className="grid grid-cols-2 md:grid-cols-2 lg:grid-cols-3 gap-8">
-        {cinemagraphProjects.map(project => (
-          <ProjectCard key={project.id} project={project} />
-        ))}
-      </div>
+      <ProjectGrid projects={cinemagraphProjects} />
     </div>
   );
 }

--- a/pages/HomePage.tsx
+++ b/pages/HomePage.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import { PROJECTS } from '../constants';
 import { Project } from '../types';
-import ProjectCard from '../components/ProjectCard';
+import ProjectGrid from '../components/ProjectGrid';
 import ChatAssistant from '../components/ChatAssistant';
 
 function HomePage(): React.ReactNode {
@@ -29,11 +29,10 @@ function HomePage(): React.ReactNode {
             featured
           </h2>
         )}
-        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
-          {displayedProjects.map(project => (
-            <ProjectCard key={project.id} project={project} />
-          ))}
-        </div>
+        <ProjectGrid
+          projects={displayedProjects}
+          gridClassName="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8"
+        />
       </section>
       <ChatAssistant onSearch={handleAiSearch} />
     </div>

--- a/pages/ImagesPage.tsx
+++ b/pages/ImagesPage.tsx
@@ -2,7 +2,7 @@
 import React from 'react';
 import { PROJECTS } from '../constants';
 import { ProjectType } from '../types';
-import ProjectCard from '../components/ProjectCard';
+import ProjectGrid from '../components/ProjectGrid';
 
 function ImagesPage(): React.ReactNode {
   const photoProjects = PROJECTS.filter(p => p.type === ProjectType.Photo).sort((a, b) => {
@@ -19,11 +19,7 @@ function ImagesPage(): React.ReactNode {
         <h1 className="text-3xl sm:text-4xl font-bold text-brand-text mb-2">images</h1>
         <p className="text-lg text-brand-text-secondary">static moments.</p>
       </section>
-      <div className="grid grid-cols-2 md:grid-cols-2 lg:grid-cols-3 gap-8">
-        {photoProjects.map(project => (
-          <ProjectCard key={project.id} project={project} />
-        ))}
-      </div>
+      <ProjectGrid projects={photoProjects} />
     </div>
   );
 }

--- a/pages/PhotosPage.tsx
+++ b/pages/PhotosPage.tsx
@@ -2,7 +2,7 @@
 import React from 'react';
 import { PROJECTS } from '../constants';
 import { ProjectType } from '../types';
-import ProjectCard from '../components/ProjectCard';
+import ProjectGrid from '../components/ProjectGrid';
 
 function PhotosPage(): React.ReactNode {
   const photoProjects = PROJECTS.filter(p => p.type === ProjectType.Photo).sort((a, b) => {
@@ -19,11 +19,7 @@ function PhotosPage(): React.ReactNode {
         <h1 className="text-3xl sm:text-4xl font-bold text-brand-text mb-2">photography</h1>
         <p className="text-lg text-brand-text-secondary">Capturing moments, one frame at a time.</p>
       </section>
-      <div className="grid grid-cols-2 md:grid-cols-2 lg:grid-cols-3 gap-8">
-        {photoProjects.map(project => (
-          <ProjectCard key={project.id} project={project} />
-        ))}
-      </div>
+      <ProjectGrid projects={photoProjects} />
     </div>
   );
 }

--- a/pages/ToolsPage.tsx
+++ b/pages/ToolsPage.tsx
@@ -2,7 +2,7 @@
 import React from 'react';
 import { PROJECTS } from '../constants';
 import { ProjectType } from '../types';
-import ProjectCard from '../components/ProjectCard';
+import ProjectGrid from '../components/ProjectGrid';
 
 function ToolsPage(): React.ReactNode {
   const toolProjects = PROJECTS.filter(p => p.type === ProjectType.Tool).sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime());
@@ -13,11 +13,7 @@ function ToolsPage(): React.ReactNode {
         <h1 className="text-3xl sm:text-4xl font-bold text-brand-text mb-2">tools</h1>
         <p className="text-lg text-brand-text-secondary">just testing.</p>
       </section>
-      <div className="grid grid-cols-2 md:grid-cols-2 lg:grid-cols-3 gap-8">
-        {toolProjects.map(project => (
-          <ProjectCard key={project.id} project={project} />
-        ))}
-      </div>
+      <ProjectGrid projects={toolProjects} />
     </div>
   );
 }

--- a/pages/VideosPage.tsx
+++ b/pages/VideosPage.tsx
@@ -2,7 +2,7 @@
 import React from 'react';
 import { PROJECTS } from '../constants';
 import { ProjectType } from '../types';
-import ProjectCard from '../components/ProjectCard';
+import ProjectGrid from '../components/ProjectGrid';
 
 function VideosPage(): React.ReactNode {
   const videoProjects = PROJECTS.filter(p => p.type === ProjectType.Video).sort((a, b) => {
@@ -19,11 +19,7 @@ function VideosPage(): React.ReactNode {
         <h1 className="text-3xl sm:text-4xl font-bold text-brand-text mb-2">videos</h1>
         <p className="text-lg text-brand-text-secondary">welcome.</p>
       </section>
-      <div className="grid grid-cols-2 md:grid-cols-2 lg:grid-cols-3 gap-8">
-        {videoProjects.map(project => (
-          <ProjectCard key={project.id} project={project} />
-        ))}
-      </div>
+      <ProjectGrid projects={videoProjects} />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- add reusable project grid and modal components that present media inline with navigation and fullscreen support
- update all portfolio pages and the homepage to use the modal-enabled grid instead of opening new tabs
- enhance project cards to trigger the modal while preserving a fallback for direct links

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d3823d58008321b9d866e8ffcfe821