### PR TITLE
Add background removal tool accessible from links

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -9,6 +9,7 @@ import VideosPage from './pages/VideosPage';
 import ToolsPage from './pages/ToolsPage';
 import CinemagraphsPage from './pages/CinemagraphsPage';
 import LinksPage from './pages/LinksPage';
+import BackgroundRemovalPage from './pages/BackgroundRemovalPage';
 
 function App(): React.ReactNode {
   return (
@@ -23,6 +24,7 @@ function App(): React.ReactNode {
             <Route path="/cinemagraphs" element={<CinemagraphsPage />} />
             <Route path="/tools" element={<ToolsPage />} />
             <Route path="/links" element={<LinksPage />} />
+            <Route path="/links/background-removal" element={<BackgroundRemovalPage />} />
           </Routes>
         </main>
         

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,8 @@
       "version": "0.0.0",
       "dependencies": {
         "@google/genai": "^1.15.0",
+        "@imgly/background-removal": "^1.7.0",
+        "onnxruntime-web": "^1.21.0",
         "react": "^19.1.1",
         "react-dom": "^19.1.1",
         "react-router-dom": "^7.8.1"
@@ -779,6 +781,20 @@
         }
       }
     },
+    "node_modules/@imgly/background-removal": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@imgly/background-removal/-/background-removal-1.7.0.tgz",
+      "integrity": "sha512-/1ZryrMYg2ckIvJKoTu5Np50JfYMVffDMlVmppw/BdbN3pBTN7e6stI5/7E/LVh9DDzz6J588s7sWqul3fy5wA==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "lodash-es": "^4.17.21",
+        "ndarray": "~1.0.0",
+        "zod": "^3.23.8"
+      },
+      "peerDependencies": {
+        "onnxruntime-web": "1.21.0"
+      }
+    },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
@@ -817,6 +833,70 @@
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
+    },
+    "node_modules/@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/codegen": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
+      "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/eventemitter": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
+      "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/fetch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
+      "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.1",
+        "@protobufjs/inquire": "^1.1.0"
+      }
+    },
+    "node_modules/@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/inquire": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
+      "integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/utf8": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
+      "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-beta.32",
@@ -1161,7 +1241,6 @@
       "version": "22.17.2",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.17.2.tgz",
       "integrity": "sha512-gL6z5N9Jm9mhY+U2KXZpteb+09zyffliRkZyZOHODGATyC5B1Jt/7TzuuiLkFsSUMLbS1OLmlj/E+/3KF4Q/4w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
@@ -1411,6 +1490,12 @@
         }
       }
     },
+    "node_modules/flatbuffers": {
+      "version": "25.9.23",
+      "resolved": "https://registry.npmjs.org/flatbuffers/-/flatbuffers-25.9.23.tgz",
+      "integrity": "sha512-MI1qs7Lo4Syw0EOzUl0xjs2lsoeqFku44KpngfIduHBYvzm8h2+7K8YMQh1JtVVVrUvhLpNwqVi4DERegUJhPQ==",
+      "license": "Apache-2.0"
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -1505,6 +1590,12 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/guid-typescript": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/guid-typescript/-/guid-typescript-1.0.9.tgz",
+      "integrity": "sha512-Y8T4vYhEfwJOTbouREvG+3XDsjr8E3kIr7uf+JZ0BYloFsttiHU0WfvANVsR7TxNUJa/WpCnw/Ino/p+DeBhBQ==",
+      "license": "ISC"
+    },
     "node_modules/https-proxy-agent": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
@@ -1517,6 +1608,18 @@
       "engines": {
         "node": ">= 14"
       }
+    },
+    "node_modules/iota-array": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/iota-array/-/iota-array-1.0.0.tgz",
+      "integrity": "sha512-pZ2xT+LOHckCatGQ3DcG/a+QuEqvoxqkiL7tvE8nn3uuu+f6i1TtpB5/FtWFbxUuVr5PZCx8KskuGatbJDXOWA==",
+      "license": "MIT"
+    },
+    "node_modules/is-buffer": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+      "license": "MIT"
     },
     "node_modules/is-stream": {
       "version": "2.0.1",
@@ -1593,6 +1696,18 @@
         "safe-buffer": "^5.0.1"
       }
     },
+    "node_modules/lodash-es": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
+      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==",
+      "license": "MIT"
+    },
+    "node_modules/long": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+      "license": "Apache-2.0"
+    },
     "node_modules/lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -1628,6 +1743,16 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
+    "node_modules/ndarray": {
+      "version": "1.0.19",
+      "resolved": "https://registry.npmjs.org/ndarray/-/ndarray-1.0.19.tgz",
+      "integrity": "sha512-B4JHA4vdyZU30ELBw3g7/p9bZupyew5a7tX1Y/gGeF2hafrPaQZhgrGQfsvgfYbgdFZjYwuEcnaobeM/WMW+HQ==",
+      "license": "MIT",
+      "dependencies": {
+        "iota-array": "^1.0.0",
+        "is-buffer": "^1.0.2"
+      }
+    },
     "node_modules/node-fetch": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
@@ -1655,6 +1780,26 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/onnxruntime-common": {
+      "version": "1.21.0",
+      "resolved": "https://registry.npmjs.org/onnxruntime-common/-/onnxruntime-common-1.21.0.tgz",
+      "integrity": "sha512-Q632iLLrtCAVOTO65dh2+mNbQir/QNTVBG3h/QdZBpns7mZ0RYbLRBgGABPbpU9351AgYy7SJf1WaeVwMrBFPQ==",
+      "license": "MIT"
+    },
+    "node_modules/onnxruntime-web": {
+      "version": "1.21.0",
+      "resolved": "https://registry.npmjs.org/onnxruntime-web/-/onnxruntime-web-1.21.0.tgz",
+      "integrity": "sha512-adzOe+7uI7lKz6pQNbAsLMQd2Fq5Jhmoxd8LZjJr8m3KvbFyiYyRxRiC57/XXD+jb18voppjeGAjoZmskXG+7A==",
+      "license": "MIT",
+      "dependencies": {
+        "flatbuffers": "^25.1.24",
+        "guid-typescript": "^1.0.9",
+        "long": "^5.2.3",
+        "onnxruntime-common": "1.21.0",
+        "platform": "^1.3.6",
+        "protobufjs": "^7.2.4"
+      }
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -1674,6 +1819,12 @@
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
       }
+    },
+    "node_modules/platform": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/platform/-/platform-1.3.6.tgz",
+      "integrity": "sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg==",
+      "license": "MIT"
     },
     "node_modules/postcss": {
       "version": "8.5.6",
@@ -1702,6 +1853,30 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/protobufjs": {
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.4.tgz",
+      "integrity": "sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==",
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.4",
+        "@protobufjs/eventemitter": "^1.1.0",
+        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/inquire": "^1.1.0",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.0",
+        "@types/node": ">=13.7.0",
+        "long": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/react": {
@@ -1906,7 +2081,6 @@
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/update-browserslist-db": {
@@ -2071,6 +2245,15 @@
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -10,6 +10,8 @@
   },
   "dependencies": {
     "@google/genai": "^1.15.0",
+    "@imgly/background-removal": "^1.7.0",
+    "onnxruntime-web": "^1.21.0",
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
     "react-router-dom": "^7.8.1"

--- a/pages/BackgroundRemovalPage.tsx
+++ b/pages/BackgroundRemovalPage.tsx
@@ -1,0 +1,223 @@
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { Link } from 'react-router-dom';
+import { removeBackground } from '@imgly/background-removal';
+
+type ProcessingState = 'idle' | 'loading' | 'success' | 'error';
+
+type StatusMessage = {
+  label: string;
+  tone: 'default' | 'success' | 'error';
+};
+
+const downloadFilename = 'laundromatzat-background-removed.png';
+
+function BackgroundRemovalPage(): React.ReactNode {
+  const [sourcePreview, setSourcePreview] = useState<string | null>(null);
+  const [resultPreview, setResultPreview] = useState<string | null>(null);
+  const [processingState, setProcessingState] = useState<ProcessingState>('idle');
+  const [statusMessage, setStatusMessage] = useState<StatusMessage | null>(null);
+  const [progressMessage, setProgressMessage] = useState<string | null>(null);
+
+  const reset = useCallback(() => {
+    setProcessingState('idle');
+    setStatusMessage(null);
+    setProgressMessage(null);
+    setResultPreview(prev => {
+      if (prev) {
+        URL.revokeObjectURL(prev);
+      }
+      return null;
+    });
+    setSourcePreview(prev => {
+      if (prev) {
+        URL.revokeObjectURL(prev);
+      }
+      return null;
+    });
+  }, []);
+
+  const showStatus = useCallback((label: string, tone: StatusMessage['tone'] = 'default') => {
+    setStatusMessage({ label, tone });
+  }, []);
+
+  const handleFile = useCallback(async (file: File) => {
+    reset();
+    const previewUrl = URL.createObjectURL(file);
+    setSourcePreview(previewUrl);
+    setProcessingState('loading');
+    showStatus('Preparing your photo…');
+
+    try {
+      const blob = await removeBackground(file, {
+        progress: (key, current, total) => {
+          const percent = total > 0 ? Math.round((current / total) * 100) : 0;
+          setProgressMessage(`${key.replace(/_/g, ' ')} ${percent}%`);
+        },
+      });
+
+      const resultUrl = URL.createObjectURL(blob);
+      setResultPreview(resultUrl);
+      setProcessingState('success');
+      showStatus('Background removed! Download the PNG below.', 'success');
+      setProgressMessage(null);
+    } catch (error) {
+      console.error('Background removal failed', error);
+      setProcessingState('error');
+      showStatus('Something went wrong while processing the photo. Please try another image.', 'error');
+      setProgressMessage(null);
+    }
+  }, [reset, showStatus]);
+
+  const handleInputChange = useCallback(
+    (event: React.ChangeEvent<HTMLInputElement>) => {
+      const file = event.target.files?.[0];
+      if (file) {
+        void handleFile(file);
+      }
+      event.target.value = '';
+    },
+    [handleFile],
+  );
+
+  const dropHandlers = useMemo(() => {
+    const onDrop = (event: React.DragEvent<HTMLLabelElement>) => {
+      event.preventDefault();
+      const file = event.dataTransfer.files && event.dataTransfer.files[0];
+      if (file) {
+        void handleFile(file);
+      }
+    };
+
+    const onDragOver = (event: React.DragEvent<HTMLLabelElement>) => {
+      event.preventDefault();
+    };
+
+    return { onDrop, onDragOver };
+  }, [handleFile]);
+
+  const downloadLink = useMemo(() => {
+    if (!resultPreview) {
+      return null;
+    }
+
+    return (
+      <a
+        href={resultPreview}
+        download={downloadFilename}
+        className="inline-flex items-center justify-center rounded-md bg-brand-accent px-4 py-2 font-medium text-brand-primary shadow-lg transition-transform duration-150 hover:-translate-y-0.5 hover:shadow-xl focus:outline-none focus:ring-2 focus:ring-brand-accent focus:ring-offset-2 focus:ring-offset-brand-primary"
+      >
+        download png
+      </a>
+    );
+  }, [resultPreview]);
+
+  useEffect(() => {
+    return () => {
+      if (sourcePreview) {
+        URL.revokeObjectURL(sourcePreview);
+      }
+    };
+  }, [sourcePreview]);
+
+  useEffect(() => {
+    return () => {
+      if (resultPreview) {
+        URL.revokeObjectURL(resultPreview);
+      }
+    };
+  }, [resultPreview]);
+
+  return (
+    <div className="space-y-10">
+      <section className="space-y-4">
+        <div className="flex items-center gap-4 text-brand-text-secondary">
+          <Link to="/links" className="text-brand-accent hover:underline">
+            ← back to links
+          </Link>
+          <span className="text-sm">remove backgrounds right in the browser.</span>
+        </div>
+        <h1 className="text-3xl sm:text-4xl font-bold text-brand-text">background remover</h1>
+        <p className="text-lg text-brand-text-secondary max-w-2xl">
+          Upload a photo and our in-browser model will isolate the main subject. You&apos;ll get a transparent PNG you can drop into decks, composites, or anything else that needs a clean cutout.
+        </p>
+      </section>
+
+      <section className="grid gap-8 lg:grid-cols-2">
+        <div className="space-y-6">
+          <label
+            htmlFor="background-remover-input"
+            className="flex h-60 cursor-pointer flex-col items-center justify-center gap-4 rounded-xl border-2 border-dashed border-brand-secondary/60 bg-brand-secondary/20 p-6 text-center text-brand-text-secondary transition-colors hover:border-brand-accent hover:text-brand-text"
+            {...dropHandlers}
+          >
+            <input
+              id="background-remover-input"
+              type="file"
+              accept="image/*"
+              onChange={handleInputChange}
+              className="hidden"
+            />
+            <div className="flex flex-col items-center gap-2">
+              <span className="text-sm uppercase tracking-wide">drop or click</span>
+              <span className="text-2xl font-semibold text-brand-text">your photo</span>
+            </div>
+            <p className="max-w-xs text-sm text-brand-text-secondary">
+              PNG and JPEG work best. We keep everything in the browser, so nothing ever leaves this page.
+            </p>
+          </label>
+
+          {statusMessage && (
+            <div
+              className={`rounded-lg border px-4 py-3 text-sm ${
+                statusMessage.tone === 'success'
+                  ? 'border-emerald-300/60 bg-emerald-400/10 text-emerald-200'
+                  : statusMessage.tone === 'error'
+                    ? 'border-rose-300/60 bg-rose-400/10 text-rose-200'
+                    : 'border-brand-secondary/60 bg-brand-secondary/20 text-brand-text-secondary'
+              }`}
+            >
+              {statusMessage.label}
+              {progressMessage && (
+                <span className="mt-1 block text-xs opacity-80">{progressMessage}</span>
+              )}
+            </div>
+          )}
+
+          {processingState === 'success' && downloadLink}
+        </div>
+
+        <div className="grid gap-6">
+          <div className="overflow-hidden rounded-xl border border-brand-secondary/60 bg-brand-secondary/20 p-4">
+            <h2 className="mb-3 text-sm font-semibold uppercase tracking-wide text-brand-text-secondary">original</h2>
+            <div className="flex h-72 items-center justify-center rounded-lg bg-brand-primary/40">
+              {sourcePreview ? (
+                <img src={sourcePreview} alt="Uploaded" className="max-h-full max-w-full object-contain" />
+              ) : (
+                <span className="text-sm text-brand-text-secondary">no image yet</span>
+              )}
+            </div>
+          </div>
+
+          <div className="overflow-hidden rounded-xl border border-brand-secondary/60 bg-brand-secondary/20 p-4">
+            <h2 className="mb-3 text-sm font-semibold uppercase tracking-wide text-brand-text-secondary">background removed</h2>
+            <div className="flex h-72 items-center justify-center rounded-lg bg-brand-primary/40">
+              {processingState === 'loading' && (
+                <span className="text-sm text-brand-text-secondary">processing… this can take a moment the first time.</span>
+              )}
+              {processingState === 'success' && resultPreview && (
+                <img src={resultPreview} alt="Background removed result" className="max-h-full max-w-full object-contain" />
+              )}
+              {processingState === 'idle' && !resultPreview && (
+                <span className="text-sm text-brand-text-secondary">result preview will show here</span>
+              )}
+              {processingState === 'error' && (
+                <span className="text-sm text-rose-200">we couldn&apos;t process that image. try another one?</span>
+              )}
+            </div>
+          </div>
+        </div>
+      </section>
+    </div>
+  );
+}
+
+export default BackgroundRemovalPage;

--- a/pages/LinksPage.tsx
+++ b/pages/LinksPage.tsx
@@ -1,27 +1,35 @@
 import React, { useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
 
-interface Link {
+interface Bookmark {
   url: string;
   description: string;
 }
 
 function LinksPage(): React.ReactNode {
-  const [links, setLinks] = useState<Link[]>([]);
+  const [links, setLinks] = useState<Bookmark[]>([]);
 
   useEffect(() => {
     fetch('/data/links.csv')
       .then(response => response.text())
       .then(text => {
         const rows = text.split('\n');
-        const headers = rows[0].split(',');
-        const linksData = rows.slice(1).map(row => {
-          const values = row.split(',');
-          return {
-            url: values[0],
-            description: values[1]
-          };
-        });
+        const linksData = rows
+          .slice(1)
+          .map(row => row.trim())
+          .filter(row => row.length > 0)
+          .map(row => {
+            const [url, ...descriptionParts] = row.split(',');
+            return {
+              url: url.trim(),
+              description: descriptionParts.join(',').trim(),
+            };
+          })
+          .filter(link => link.url && link.description);
         setLinks(linksData);
+      })
+      .catch(error => {
+        console.error('Failed to load links', error);
       });
   }, []);
 
@@ -31,13 +39,35 @@ function LinksPage(): React.ReactNode {
         <h1 className="text-3xl sm:text-4xl font-bold text-brand-text mb-2">links</h1>
         <p className="text-lg text-brand-text-secondary">a collection of bookmarks.</p>
       </section>
-      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
-        {links.map(link => (
-          <a href={link.url} target="_blank" rel="noopener noreferrer" className="text-brand-text-secondary hover:text-brand-text">
-            {link.description}
-          </a>
-        ))}
-      </div>
+      <section className="space-y-6">
+        <Link
+          to="/links/background-removal"
+          className="block rounded-2xl border border-brand-secondary/60 bg-brand-secondary/20 p-6 shadow-sm transition-transform duration-150 hover:-translate-y-1 hover:shadow-xl"
+        >
+          <div className="flex flex-col gap-3 text-brand-text">
+            <span className="text-xs uppercase tracking-[0.2em] text-brand-text-secondary">new</span>
+            <h2 className="text-2xl font-semibold">remove a background</h2>
+            <p className="text-brand-text-secondary">
+              Try our in-browser background remover to turn any portrait or product photo into a transparent PNG ready for download.
+            </p>
+            <span className="text-sm font-medium text-brand-accent">open tool →</span>
+          </div>
+        </Link>
+
+        <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3">
+          {links.map(link => (
+            <a
+              key={link.url}
+              href={link.url}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="rounded-xl border border-brand-secondary/60 bg-brand-secondary/20 px-4 py-3 text-brand-text-secondary transition-colors hover:border-brand-accent hover:text-brand-text"
+            >
+              {link.description}
+            </a>
+          ))}
+        </div>
+      </section>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- add a background remover page that uses @imgly/background-removal to cut out uploads entirely in the browser and offer a downloadable PNG
- surface the new tool from the links page alongside improved CSV parsing and styling tweaks
- register the route and dependencies needed for the background removal experience

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d3864c54dc832193d4874da4d606cc