### PR TITLE
Fix Gemini API integration for tools

### DIFF
--- a/pages/IntelligentIdeasBoardPage.tsx
+++ b/pages/IntelligentIdeasBoardPage.tsx
@@ -26,14 +26,22 @@ const IntelligentIdeasBoardPage = () => {
     setIsProcessing(true);
     
     if (inputMode === 'instruction') {
-        if (!organizedData) {
-            alert("Please add some content first before giving organizational instructions.");
-            setIsProcessing(false);
-            return;
-        }
-      await reorganizeWithInstruction(inputText, organizedData, allInputs);
-      setInputText('');
-      setIsProcessing(false);
+      if (!organizedData) {
+        alert("Please add some content first before giving organizational instructions.");
+        setIsProcessing(false);
+        return;
+      }
+
+      try {
+        const reorganized = await reorganizeWithInstruction(inputText, organizedData, allInputs);
+        setOrganizedData(reorganized);
+        setInputText('');
+      } catch (error) {
+        console.error('Error applying instruction:', error);
+        alert("Sorry, there was an error applying your instruction. Please try again.");
+      } finally {
+        setIsProcessing(false);
+      }
       return;
     }
 

--- a/pages/ToolsPage.tsx
+++ b/pages/ToolsPage.tsx
@@ -2,6 +2,37 @@ import React from 'react';
 import { Link } from 'react-router-dom';
 import PageMetadata from '../components/PageMetadata';
 
+const TOOL_LINKS = [
+  {
+    to: '/tools/background-removal',
+    ariaLabel: 'Remove a background',
+    title: 'Remove a background',
+    description: "Launch the in-browser background removal tool to generate a transparent PNG that's ready to download in seconds.",
+    cta: 'Try the background removal tool',
+  },
+  {
+    to: '/tools/color-palette',
+    ariaLabel: 'Extract a color palette',
+    title: 'Extract a color palette',
+    description: 'Upload an image and instantly generate a five-color palette with copy-ready values.',
+    cta: 'Try the color palette tool',
+  },
+  {
+    to: '/tools/nylon-fabric-designer',
+    ariaLabel: 'Nylon Fabric Project Designer',
+    title: 'Nylon Fabric Project Designer',
+    description: 'Describe your project and get professional sewing guidance with cutting templates and visual previews.',
+    cta: 'Try the fabric designer tool',
+  },
+  {
+    to: '/tools/intelligent-ideas-board',
+    ariaLabel: 'Intelligent Ideas Board',
+    title: 'Intelligent Ideas Board',
+    description: "Drop your thoughts, ideas, and tasks, and let the assistant organize them for you.",
+    cta: 'Try the ideas board tool',
+  },
+];
+
 function ToolsPage(): React.ReactNode {
   return (
     <div className="space-y-space-5">
@@ -19,61 +50,21 @@ function ToolsPage(): React.ReactNode {
       </header>
 
       <section className="space-y-space-4" aria-label="Featured tools">
-        <Link
-          to="/tools/background-removal"
-          className="block rounded-radius-lg border border-brand-surface-highlight/60 bg-brand-secondary/40 p-6 shadow-layer-1 transition hover:-translate-y-1 hover:shadow-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-accent/60 focus-visible:ring-offset-2 focus-visible:ring-offset-brand-primary"
-        >
-          <div className="flex flex-col gap-3 text-brand-text">
-            <span className="text-xs font-semibold uppercase tracking-[0.3em] text-brand-text-secondary">New</span>
-            <h2 className="text-2xl font-semibold">Remove a background</h2>
-            <p className="text-brand-text-secondary">
-              Launch the in-browser background removal tool to generate a transparent PNG that&apos;s ready to download in seconds.
-            </p>
-            <span className="text-sm font-medium text-brand-accent">Try the background removal tool</span>
-          </div>
-        </Link>
-
-                <Link
-          to="/tools/color-palette"
-          className="block rounded-radius-lg border border-brand-surface-highlight/60 bg-brand-secondary/40 p-6 shadow-layer-1 transition hover:-translate-y-1 hover:shadow-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-accent/60 focus-visible:ring-offset-2 focus-visible:ring-offset-brand-primary"
-        >
-          <div className="flex flex-col gap-3 text-brand-text">
-            <span className="text-xs font-semibold uppercase tracking-[0.3em] text-brand-text-secondary">New</span>
-            <h2 className="text-2xl font-semibold">Extract a color palette</h2>
-            <p className="text-brand-text-secondary">
-              Upload an image and instantly generate a five-color palette with copy-ready values.
-            </p>
-            <span className="text-sm font-medium text-brand-accent">Try the color palette tool</span>
-          </div>
-        </Link>
-
-        <Link
-          to="/tools/nylon-fabric-designer"
-          className="block rounded-radius-lg border border-brand-surface-highlight/60 bg-brand-secondary/40 p-6 shadow-layer-1 transition hover:-translate-y-1 hover:shadow-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-accent/60 focus-visible:ring-offset-2 focus-visible:ring-offset-brand-primary"
-        >
-          <div className="flex flex-col gap-3 text-brand-text">
-            <span className="text-xs font-semibold uppercase tracking-[0.3em] text-brand-text-secondary">New</span>
-            <h2 className="text-2xl font-semibold">Nylon Fabric Project Designer</h2>
-            <p className="text-brand-text-secondary">
-              Describe your project and get professional sewing guidance with cutting templates and visual previews.
-            </p>
-            <span className="text-sm font-medium text-brand-accent">Try the fabric designer tool</span>
-          </div>
-        </Link>
-
-        <Link
-            to="/tools/intelligent-ideas-board"
+        {TOOL_LINKS.map(tool => (
+          <Link
+            key={tool.to}
+            to={tool.to}
+            aria-label={tool.ariaLabel}
             className="block rounded-radius-lg border border-brand-surface-highlight/60 bg-brand-secondary/40 p-6 shadow-layer-1 transition hover:-translate-y-1 hover:shadow-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-accent/60 focus-visible:ring-offset-2 focus-visible:ring-offset-brand-primary"
-        >
+          >
             <div className="flex flex-col gap-3 text-brand-text">
-                <span className="text-xs font-semibold uppercase tracking-[0.3em] text-brand-text-secondary">New</span>
-                <h2 className="text-2xl font-semibold">Intelligent Ideas Board</h2>
-                <p className="text-brand-text-secondary">
-                    Drop your thoughts, ideas, and tasks, and let the assistant organize them for you.
-                </p>
-                <span className="text-sm font-medium text-brand-accent">Try the ideas board tool</span>
+              <span className="text-xs font-semibold uppercase tracking-[0.3em] text-brand-text-secondary">New</span>
+              <h2 className="text-2xl font-semibold">{tool.title}</h2>
+              <p className="text-brand-text-secondary">{tool.description}</p>
+              <span className="text-sm font-medium text-brand-accent">{tool.cta}</span>
             </div>
-        </Link>
+          </Link>
+        ))}
       </section>
     </div>
   );

--- a/server/routes/geminiRoutes.ts
+++ b/server/routes/geminiRoutes.ts
@@ -23,5 +23,23 @@ export function createGeminiRouter(service: GeminiService): Router {
     }
   });
 
+  router.post('/generate-content', async (req, res) => {
+    try {
+      const { prompt } = req.body;
+      if (typeof prompt !== 'string') {
+        return res.status(400).json({ error: 'Prompt must be a string.' });
+      }
+
+      const responseText = await service.generateContent(prompt);
+      res.json({ content: responseText });
+
+    } catch (error) {
+      console.error('Gemini generateContent error:', error);
+      res.status(500).json({
+        error: error instanceof Error ? error.message : 'An unexpected error occurred.',
+      });
+    }
+  });
+
   return router;
 }

--- a/server/services/geminiService.ts
+++ b/server/services/geminiService.ts
@@ -52,17 +52,27 @@ export class GeminiService {
   }
 
   async generateContent(prompt: string): Promise<string> {
-    const model = this.ai.getGenerativeModel({ model: 'gemini-1.5-pro-latest' });
-    const result = await model.generateContent(prompt);
-    const response = await result.response;
-    return response.text();
+    try {
+      const model = this.ai.getGenerativeModel({ model: 'gemini-1.5-pro-latest' });
+      const result = await model.generateContent(prompt);
+      const response = await result.response;
+      return response.text();
+    } catch (error) {
+      console.error('Gemini generateContent failure:', error);
+      throw error instanceof Error ? error : new Error('Failed to generate content with Gemini.');
+    }
   }
 
   async sendMessage(message: string): Promise<string> {
-    const chat = this.getChatSession();
-    const result = await chat.sendMessage(message);
-    const response = await result.response;
-    return response.text();
+    try {
+      const chat = this.getChatSession();
+      const result = await chat.sendMessage(message);
+      const response = await result.response;
+      return response.text();
+    } catch (error) {
+      console.error('Gemini chat failure:', error);
+      throw error instanceof Error ? error : new Error('Failed to send chat message to Gemini.');
+    }
   }
 }
 

--- a/services/intelligentIdeasService.ts
+++ b/services/intelligentIdeasService.ts
@@ -74,7 +74,13 @@ CRITICAL: Respond ONLY with valid JSON. Do not include any text before or after 
 
   const responseText = await generateContent(prompt);
   const cleanJson = responseText.replace(/```json\n?/g, "").replace(/```\n?/g, "").trim();
-  return JSON.parse(cleanJson);
+
+  try {
+    return JSON.parse(cleanJson);
+  } catch (error) {
+    console.error('Failed to parse organization response:', error, responseText);
+    throw new Error('The ideas assistant returned an invalid response. Please try again.');
+  }
 };
 
 export const reorganizeWithInstruction = async (instruction: string, organizedData: OrganizedData, allInputs: string[]): Promise<OrganizedData> => {
@@ -101,5 +107,12 @@ CRITICAL: Respond ONLY with valid JSON. Do not include any text before or after 
 
     const responseText = await generateContent(prompt);
     const cleanJson = responseText.replace(/```json\n?/g, "").replace(/```\n?/g, "").trim();
-    return JSON.parse(cleanJson);
+
+    try {
+        return JSON.parse(cleanJson);
+    } catch (error) {
+        console.error('Failed to parse reorganize response:', error, responseText);
+        throw new Error('The ideas assistant returned an invalid response. Please try again.');
+    }
 };
+

--- a/services/nylonFabricDesignerService.ts
+++ b/services/nylonFabricDesignerService.ts
@@ -97,6 +97,12 @@ Make the SVGs detailed, technical, and professional looking with:
 
   const responseText = await generateContent(prompt);
   const cleanJson = responseText.replace(/```json/g, "").replace(/```/g, "").trim();
-  const visuals = VisualsResponseSchema.parse(JSON.parse(cleanJson));
-  return visuals;
+
+  try {
+    const visuals = VisualsResponseSchema.parse(JSON.parse(cleanJson));
+    return visuals;
+  } catch (error) {
+    console.error('Failed to parse project visuals response:', error, responseText);
+    throw new Error('The fabric designer returned an invalid visualization response. Please try again.');
+  }
 }


### PR DESCRIPTION
## Summary
- expose a dedicated /api/generate-content route that uses Gemini generateContent with better error reporting
- update client Gemini service and downstream nylon fabric and ideas board helpers to call the new endpoint and handle bad JSON
- refresh the tools landing page links and fix the ideas board to apply reorganized data from Gemini

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68df00e886d88321acbe48146ad580af