### PR TITLE
Improve menu icon sizing and newsletter layout

### DIFF
--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -83,13 +83,13 @@ function Header(): React.ReactNode {
           <button
             ref={menuButtonRef}
             type="button"
-            className="inline-flex items-center justify-center rounded-radius-md border border-brand-surface-highlight/60 bg-brand-secondary px-3 py-2 text-brand-text md:hidden"
+            className="inline-flex h-11 w-11 items-center justify-center rounded-radius-md border border-brand-surface-highlight/60 bg-brand-secondary text-brand-text shadow-layer-1 transition hover:bg-brand-secondary/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-accent/60 focus-visible:ring-offset-2 focus-visible:ring-offset-brand-primary md:hidden"
             aria-controls="mobile-navigation"
             aria-expanded={isMenuOpen}
             onClick={() => setIsMenuOpen(prev => !prev)}
           >
             <span className="sr-only">Toggle navigation</span>
-            {isMenuOpen ? <CloseIcon className="h-6 w-6" /> : <MenuIcon className="h-6 w-6" />}
+            {isMenuOpen ? <CloseIcon className="h-5 w-5" /> : <MenuIcon className="h-5 w-5" />}
           </button>
         </div>
       </nav>
@@ -121,10 +121,10 @@ function Header(): React.ReactNode {
                 <button
                   type="button"
                   onClick={() => setIsMenuOpen(false)}
-                  className="rounded-radius-md p-2 text-brand-text-secondary transition hover:text-brand-text"
+                  className="inline-flex h-10 w-10 items-center justify-center rounded-radius-md border border-brand-surface-highlight/60 text-brand-text-secondary transition hover:text-brand-text focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-accent/60 focus-visible:ring-offset-2 focus-visible:ring-offset-brand-secondary"
                 >
                   <span className="sr-only">Close menu</span>
-                  <CloseIcon className="h-6 w-6" />
+                  <CloseIcon className="h-5 w-5" />
                 </button>
               </div>
               <ul className="space-y-2" role="list">

--- a/components/MailingListSignup.tsx
+++ b/components/MailingListSignup.tsx
@@ -61,7 +61,11 @@ function MailingListSignup(): React.ReactNode {
           </p>
         </div>
 
-        <form className="grid gap-4 md:grid-cols-[minmax(0,1fr)_minmax(0,1fr)_auto] md:items-end" onSubmit={handleSubmit} noValidate>
+        <form
+          className="grid gap-4 sm:grid-cols-1 md:grid-cols-[minmax(0,1fr)_minmax(0,1fr)_minmax(13rem,auto)] md:items-end md:gap-6"
+          onSubmit={handleSubmit}
+          noValidate
+        >
           <div className="space-y-1">
             <label htmlFor={emailId} className="text-sm font-medium text-brand-text">
               Email address
@@ -74,7 +78,7 @@ function MailingListSignup(): React.ReactNode {
               required
               value={email}
               onChange={event => setEmail(event.target.value)}
-              className="w-full rounded-radius-md border border-brand-surface-highlight/60 bg-brand-primary/60 px-3 py-2 text-brand-text placeholder:text-brand-text-secondary/70 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-accent/60 focus-visible:ring-offset-2 focus-visible:ring-offset-brand-primary"
+              className="w-full rounded-radius-md border border-brand-surface-highlight/60 bg-brand-primary/60 px-3 py-3 text-brand-text placeholder:text-brand-text-secondary/70 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-accent/60 focus-visible:ring-offset-2 focus-visible:ring-offset-brand-primary"
             />
             <p className="text-xs text-brand-text-secondary">We&apos;ll never share your email address.</p>
           </div>
@@ -90,14 +94,14 @@ function MailingListSignup(): React.ReactNode {
               value={name}
               maxLength={120}
               onChange={event => setName(event.target.value)}
-              className="w-full rounded-radius-md border border-brand-surface-highlight/60 bg-brand-primary/60 px-3 py-2 text-brand-text placeholder:text-brand-text-secondary/70 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-accent/60 focus-visible:ring-offset-2 focus-visible:ring-offset-brand-primary"
+              className="w-full rounded-radius-md border border-brand-surface-highlight/60 bg-brand-primary/60 px-3 py-3 text-brand-text placeholder:text-brand-text-secondary/70 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-accent/60 focus-visible:ring-offset-2 focus-visible:ring-offset-brand-primary"
             />
           </div>
 
           <button
             type="submit"
             disabled={disabled}
-            className="inline-flex items-center justify-center rounded-radius-md bg-brand-accent px-space-4 py-3 text-sm font-semibold text-brand-on-accent transition hover:bg-brand-accent-strong disabled:cursor-not-allowed disabled:opacity-60"
+            className="inline-flex h-12 w-full items-center justify-center rounded-radius-md bg-brand-accent px-space-4 text-sm font-semibold text-brand-on-accent transition hover:bg-brand-accent-strong focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-accent/60 focus-visible:ring-offset-2 focus-visible:ring-offset-brand-secondary disabled:cursor-not-allowed disabled:opacity-60 md:w-auto md:justify-self-end md:px-6"
           >
             {isSubmitting ? 'Joining…' : 'Join the newsletter'}
           </button>

--- a/components/icons/CloseIcon.tsx
+++ b/components/icons/CloseIcon.tsx
@@ -1,8 +1,19 @@
 
 import React from 'react';
+import clsx from 'clsx';
 
-export const CloseIcon: React.FC<React.SVGProps<SVGSVGElement>> = (props) => (
-  <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" {...props}>
+type CloseIconProps = React.SVGProps<SVGSVGElement>;
+
+export const CloseIcon: React.FC<CloseIconProps> = ({ className, ...props }) => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    fill="none"
+    viewBox="0 0 24 24"
+    strokeWidth={1.5}
+    stroke="currentColor"
+    className={clsx('h-6 w-6', className)}
+    {...props}
+  >
     <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
   </svg>
 );

--- a/components/icons/MenuIcon.tsx
+++ b/components/icons/MenuIcon.tsx
@@ -1,13 +1,17 @@
 import React from 'react';
+import clsx from 'clsx';
 
-function MenuIcon(): React.ReactNode {
+type MenuIconProps = React.SVGProps<SVGSVGElement>;
+
+const MenuIcon: React.FC<MenuIconProps> = ({ className, ...props }) => {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
-      className="h-6 w-6"
-      fill="none"
       viewBox="0 0 24 24"
+      fill="none"
       stroke="currentColor"
+      className={clsx('h-6 w-6', className)}
+      {...props}
     >
       <path
         strokeLinecap="round"
@@ -17,6 +21,6 @@ function MenuIcon(): React.ReactNode {
       />
     </svg>
   );
-}
+};
 
 export default MenuIcon;


### PR DESCRIPTION
## Summary
- allow the menu and close icons to accept sizing classes so the hamburger toggle and close controls render evenly
- widen the newsletter CTA column and adjust button padding to keep the signup layout balanced on medium viewports

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68df014558a083218cb15b330b49a263