### PR TITLE
Fix tools route for deployments with custom base

### DIFF
--- a/index.tsx
+++ b/index.tsx
@@ -16,7 +16,15 @@ import IntelligentIdeasBoardPage from './pages/IntelligentIdeasBoardPage';
 import NotFoundPage from './pages/NotFoundPage';
 import './styles/base.css';
 
-const baseUrl = import.meta.env.BASE_URL ?? '/';
+function normalizeBaseUrl(rawBaseUrl: string | undefined): string {
+  if (!rawBaseUrl || rawBaseUrl === '/') {
+    return '/';
+  }
+
+  return rawBaseUrl.endsWith('/') ? rawBaseUrl.slice(0, -1) : rawBaseUrl;
+}
+
+const baseUrl = normalizeBaseUrl(import.meta.env.BASE_URL);
 
 const router = createBrowserRouter(
   [


### PR DESCRIPTION
## Summary
- normalize the router basename so it never ends with a trailing slash
- ensure nested deployments resolve /tools and other routes correctly

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68df07fb1c108321b8c6eb82d44b59f5